### PR TITLE
Update Dockerfile build dependencies

### DIFF
--- a/home-assistant-streamdeck-yaml/Dockerfile
+++ b/home-assistant-streamdeck-yaml/Dockerfile
@@ -31,7 +31,7 @@ RUN apk --no-cache add \
     && apk add --no-cache --virtual .build-deps \
     gcc \
     python3-dev \
-    musl-dev \
+    libc-dev \
     libusb-dev \
     hidapi-dev \
     libffi-dev \


### PR DESCRIPTION
Replaced `musl-dev` with `libc-dev` in Dockerfile build dependencies.