### PR TITLE
Fix Alpine musl package build

### DIFF
--- a/home-assistant-streamdeck-yaml/Dockerfile
+++ b/home-assistant-streamdeck-yaml/Dockerfile
@@ -13,6 +13,8 @@ ARG VERSION=2026.1.0
 # hadolint ignore=DL3018,DL3003
 RUN apk --no-cache add \
     # Python
+    musl \
+    musl-utils \
     python3 \
     py3-pip \
     # Runtime dependencies


### PR DESCRIPTION
## Summary
- add musl and musl-utils as explicit runtime packages before installing musl-dev build headers
- allows Alpine to update the base image's pinned musl packages before resolving current Alpine 3.21 dev headers

## Verification
- docker buildx build --platform linux/amd64 --progress=plain --build-arg BUILD_ARCH=amd64 --build-arg BUILD_DATE=... --build-arg BUILD_REF=... --build-arg BUILD_VERSION=edge home-assistant-streamdeck-yaml
- docker buildx build --platform linux/arm64/v8 --progress=plain --build-arg BUILD_ARCH=aarch64 --build-arg BUILD_DATE=... --build-arg BUILD_REF=... --build-arg BUILD_VERSION=edge home-assistant-streamdeck-yaml
- git diff --check
- docker run --rm -i hadolint/hadolint < home-assistant-streamdeck-yaml/Dockerfile