### PR TITLE
Bump add-on to 2026.5.0

### DIFF
--- a/home-assistant-streamdeck-yaml/Dockerfile
+++ b/home-assistant-streamdeck-yaml/Dockerfile
@@ -7,7 +7,7 @@ ARG BUILD_ARCH=amd64
 ARG BUILD_DATE
 ARG BUILD_REF
 ARG BUILD_VERSION
-ARG VERSION=2026.1.0
+ARG VERSION=2026.5.0
 
 # Install runtime dependencies and build dependencies
 # hadolint ignore=DL3018,DL3003

--- a/home-assistant-streamdeck-yaml/config.yaml
+++ b/home-assistant-streamdeck-yaml/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Home Assistant Stream Deck
-version: "2026.1.0"
+version: "2026.5.0"
 slug: home-assistant-streamdeck-yaml
 description: >
   This add-on allows you to control your Home Assistant


### PR DESCRIPTION
## Summary
- sync the add-on version with upstream home-assistant-streamdeck-yaml v2026.5.0
- update both the Dockerfile source tag pin and Home Assistant add-on config version

## Verification
- `git diff --check`
- `yq eval .version home-assistant-streamdeck-yaml/config.yaml`
- `curl -fsI https://github.com/basnijholt/home-assistant-streamdeck-yaml/archive/refs/tags/v2026.5.0.zip`