### PR TITLE
Report add-on deployment status from manifest job

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -128,6 +128,8 @@ jobs:
     needs:
       - information
       - deploy
+    environment:
+      name: ${{ needs.information.outputs.environment }}
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Set up Docker Buildx


### PR DESCRIPTION
## Summary
- mark the manifest publish job as the GitHub deployment for edge/stable
- keep deployment status tied to the image manifest push instead of removed repository dispatch jobs

## Verification
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/deploy.yaml
- uvx yamllint .github/workflows/deploy.yaml
- git diff --check